### PR TITLE
Duplicated all static and default methods from superinterfaces

### DIFF
--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableBiConsumer.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableBiConsumer.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 
 /**
@@ -40,5 +41,12 @@ import java.util.function.BiConsumer;
  */
 @FunctionalInterface
 public interface SerializableBiConsumer<T, U> extends BiConsumer<T, U>, Serializable {
+	default SerializableBiConsumer<T, U> andThen(SerializableBiConsumer<? super T, ? super U> after) {
+		Objects.requireNonNull(after);
 
+		return (l, r) -> {
+			accept(l, r);
+			after.accept(l, r);
+		};
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableBiFunction.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableBiFunction.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.BiFunction;
 
 /**
@@ -40,5 +41,8 @@ import java.util.function.BiFunction;
  */
 @FunctionalInterface
 public interface SerializableBiFunction<T, U, R> extends BiFunction<T, U, R>, Serializable {
-
+	default <V> SerializableBiFunction<T, U, V> andThen(SerializableFunction<? super R, ? extends V> after) {
+		Objects.requireNonNull(after);
+		return (T t, U u) -> after.apply(apply(t, u));
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableBiPredicate.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableBiPredicate.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.BiPredicate;
 
 /**
@@ -40,5 +41,17 @@ import java.util.function.BiPredicate;
  */
 @FunctionalInterface
 public interface SerializableBiPredicate<T, U> extends BiPredicate<T, U>, Serializable {
+	default SerializableBiPredicate<T, U> and(SerializableBiPredicate<? super T, ? super U> other) {
+		Objects.requireNonNull(other);
+		return (T t, U u) -> test(t, u) && other.test(t, u);
+	}
 
+	default SerializableBiPredicate<T, U> negate() {
+		return (T t, U u) -> !test(t, u);
+	}
+
+	default SerializableBiPredicate<T, U> or(SerializableBiPredicate<? super T, ? super U> other) {
+		Objects.requireNonNull(other);
+		return (T t, U u) -> test(t, u) || other.test(t, u);
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableBinaryOperator.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableBinaryOperator.java
@@ -31,6 +31,8 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.function.BinaryOperator;
 
 /**
@@ -41,5 +43,13 @@ import java.util.function.BinaryOperator;
  */
 @FunctionalInterface
 public interface SerializableBinaryOperator<T> extends BinaryOperator<T>, Serializable {
+	public static <T> SerializableBinaryOperator<T> minBy(Comparator<? super T> comparator) {
+		Objects.requireNonNull(comparator);
+		return (a, b) -> comparator.compare(a, b) <= 0 ? a : b;
+	}
 
+	public static <T> SerializableBinaryOperator<T> maxBy(Comparator<? super T> comparator) {
+		Objects.requireNonNull(comparator);
+		return (a, b) -> comparator.compare(a, b) >= 0 ? a : b;
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableConsumer.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableConsumer.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -40,5 +41,11 @@ import java.util.function.Consumer;
  */
 @FunctionalInterface
 public interface SerializableConsumer<T> extends Consumer<T>, Serializable {
-
+	default SerializableConsumer<T> andThen(SerializableConsumer<? super T> after) {
+		Objects.requireNonNull(after);
+		return (T t) -> {
+			accept(t);
+			after.accept(t);
+		};
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableDoubleConsumer.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableDoubleConsumer.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.DoubleConsumer;
 
 /**
@@ -39,6 +40,12 @@ import java.util.function.DoubleConsumer;
  * @author Jakub Danek (www.danekja.org)
  */
 @FunctionalInterface
-public interface SerializableDoubleConsumer extends DoubleConsumer, Serializable{
-
+public interface SerializableDoubleConsumer extends DoubleConsumer, Serializable {
+	default SerializableDoubleConsumer andThen(SerializableDoubleConsumer after) {
+		Objects.requireNonNull(after);
+		return (double t) -> {
+			accept(t);
+			after.accept(t);
+		};
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableDoublePredicate.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableDoublePredicate.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.DoublePredicate;
 
 /**
@@ -40,5 +41,17 @@ import java.util.function.DoublePredicate;
  */
 @FunctionalInterface
 public interface SerializableDoublePredicate extends DoublePredicate, Serializable {
+	default SerializableDoublePredicate and(SerializableDoublePredicate other) {
+		Objects.requireNonNull(other);
+		return (value) -> test(value) && other.test(value);
+	}
 
+	default SerializableDoublePredicate negate() {
+		return (value) -> !test(value);
+	}
+
+	default SerializableDoublePredicate or(SerializableDoublePredicate other) {
+		Objects.requireNonNull(other);
+		return (value) -> test(value) || other.test(value);
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableDoubleUnaryOperator.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableDoubleUnaryOperator.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.DoubleUnaryOperator;
 
 /**
@@ -40,5 +41,17 @@ import java.util.function.DoubleUnaryOperator;
  */
 @FunctionalInterface
 public interface SerializableDoubleUnaryOperator extends DoubleUnaryOperator, Serializable {
+	default SerializableDoubleUnaryOperator compose(SerializableDoubleUnaryOperator before) {
+		Objects.requireNonNull(before);
+		return (double v) -> applyAsDouble(before.applyAsDouble(v));
+	}
 
+	default SerializableDoubleUnaryOperator andThen(SerializableDoubleUnaryOperator after) {
+		Objects.requireNonNull(after);
+		return (double t) -> after.applyAsDouble(applyAsDouble(t));
+	}
+
+	static SerializableDoubleUnaryOperator identity() {
+		return t -> t;
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableFunction.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableFunction.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -40,5 +41,17 @@ import java.util.function.Function;
  */
 @FunctionalInterface
 public interface SerializableFunction<T, R> extends Function<T, R>, Serializable {
+	default <V> SerializableFunction<V, R> compose(SerializableFunction<? super V, ? extends T> before) {
+		Objects.requireNonNull(before);
+		return (V v) -> apply(before.apply(v));
+	}
 
+	default <V> SerializableFunction<T, V> andThen(SerializableFunction<? super R, ? extends V> after) {
+		Objects.requireNonNull(after);
+		return (T t) -> after.apply(apply(t));
+	}
+
+	static <T> SerializableFunction<T, T> identity() {
+		return t -> t;
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableIntConsumer.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableIntConsumer.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.IntConsumer;
 
 /**
@@ -40,5 +41,11 @@ import java.util.function.IntConsumer;
  */
 @FunctionalInterface
 public interface SerializableIntConsumer extends IntConsumer, Serializable {
-
+	default SerializableIntConsumer andThen(SerializableIntConsumer after) {
+		Objects.requireNonNull(after);
+		return (int t) -> {
+			accept(t);
+			after.accept(t);
+		};
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableIntPredicate.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableIntPredicate.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.IntPredicate;
 
 /**
@@ -40,5 +41,17 @@ import java.util.function.IntPredicate;
  */
 @FunctionalInterface
 public interface SerializableIntPredicate extends IntPredicate, Serializable {
+	default SerializableIntPredicate and(SerializableIntPredicate other) {
+		Objects.requireNonNull(other);
+		return (value) -> test(value) && other.test(value);
+	}
 
+	default SerializableIntPredicate negate() {
+		return (value) -> !test(value);
+	}
+
+	default SerializableIntPredicate or(SerializableIntPredicate other) {
+		Objects.requireNonNull(other);
+		return (value) -> test(value) || other.test(value);
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableIntUnaryOperator.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableIntUnaryOperator.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.IntUnaryOperator;
 
 /**
@@ -40,5 +41,17 @@ import java.util.function.IntUnaryOperator;
  */
 @FunctionalInterface
 public interface SerializableIntUnaryOperator extends IntUnaryOperator, Serializable {
+	default SerializableIntUnaryOperator compose(SerializableIntUnaryOperator before) {
+		Objects.requireNonNull(before);
+		return (int v) -> applyAsInt(before.applyAsInt(v));
+	}
 
+	default SerializableIntUnaryOperator andThen(SerializableIntUnaryOperator after) {
+		Objects.requireNonNull(after);
+		return (int t) -> after.applyAsInt(applyAsInt(t));
+	}
+
+	static SerializableIntUnaryOperator identity() {
+		return t -> t;
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableLongConsumer.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableLongConsumer.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.LongConsumer;
 
 /**
@@ -40,5 +41,8 @@ import java.util.function.LongConsumer;
  */
 @FunctionalInterface
 public interface SerializableLongConsumer extends LongConsumer, Serializable {
-
+    default SerializableLongConsumer andThen(SerializableLongConsumer after) {
+        Objects.requireNonNull(after);
+        return (long t) -> { accept(t); after.accept(t); };
+    }
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableLongPredicate.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableLongPredicate.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.LongPredicate;
 
 /**
@@ -40,5 +41,17 @@ import java.util.function.LongPredicate;
  */
 @FunctionalInterface
 public interface SerializableLongPredicate extends LongPredicate, Serializable {
+    default SerializableLongPredicate and(SerializableLongPredicate other) {
+        Objects.requireNonNull(other);
+        return (value) -> test(value) && other.test(value);
+    }
 
+    default SerializableLongPredicate negate() {
+        return (value) -> !test(value);
+    }
+
+    default SerializableLongPredicate or(SerializableLongPredicate other) {
+        Objects.requireNonNull(other);
+        return (value) -> test(value) || other.test(value);
+    }
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableLongUnaryOperator.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableLongUnaryOperator.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.LongUnaryOperator;
 
 /**
@@ -40,5 +41,17 @@ import java.util.function.LongUnaryOperator;
  */
 @FunctionalInterface
 public interface SerializableLongUnaryOperator extends LongUnaryOperator, Serializable {
+	default SerializableLongUnaryOperator compose(SerializableLongUnaryOperator before) {
+		Objects.requireNonNull(before);
+		return (long v) -> applyAsLong(before.applyAsLong(v));
+	}
 
+	default SerializableLongUnaryOperator andThen(SerializableLongUnaryOperator after) {
+		Objects.requireNonNull(after);
+		return (long t) -> after.applyAsLong(applyAsLong(t));
+	}
+
+	static SerializableLongUnaryOperator identity() {
+		return t -> t;
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializablePredicate.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializablePredicate.java
@@ -31,6 +31,7 @@
 package org.danekja.java.util.function.serializable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 /**
@@ -40,5 +41,21 @@ import java.util.function.Predicate;
  */
 @FunctionalInterface
 public interface SerializablePredicate<T> extends Predicate<T>, Serializable {
+	default SerializablePredicate<T> and(SerializablePredicate<? super T> other) {
+		Objects.requireNonNull(other);
+		return (t) -> test(t) && other.test(t);
+	}
 
+	default SerializablePredicate<T> negate() {
+		return (t) -> !test(t);
+	}
+
+	default SerializablePredicate<T> or(SerializablePredicate<? super T> other) {
+		Objects.requireNonNull(other);
+		return (t) -> test(t) || other.test(t);
+	}
+
+	static <T> SerializablePredicate<T> isEqual(Object targetRef) {
+		return (null == targetRef) ? Objects::isNull : object -> targetRef.equals(object);
+	}
 }

--- a/src/main/java/org/danekja/java/util/function/serializable/SerializableUnaryOperator.java
+++ b/src/main/java/org/danekja/java/util/function/serializable/SerializableUnaryOperator.java
@@ -40,5 +40,7 @@ import java.util.function.UnaryOperator;
  */
 @FunctionalInterface
 public interface SerializableUnaryOperator<T> extends UnaryOperator<T>, Serializable {
-
+	static <T> SerializableUnaryOperator<T> identity() {
+		return t -> t;
+	}
 }


### PR DESCRIPTION
Methods like Predicate.negate return a new Predicate, based on the current. If these methods are not overridden, they will return non-serializable implementations. Also, methods that take other functional interfaces are overloaded to now take the Serializable interface. This ensures chains suchs as f.andThen(x -> x == 42) is also Serializable.