### PR TITLE
Add jigsaw (java module system) compliancy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <useDefaultManifestFile>true</useDefaultManifestFile>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.danekja.jdk.serializable.functional</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>9</source>
+                    <target>9</target>
+                    <release>9</release>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module org.danekja.jdk.serializable.functional
+{
+	exports org.danekja.java.misc.serializable;
+
+	exports org.danekja.java.util.function.serializable;
+
+	requires java.base;
+}


### PR DESCRIPTION
1. Updated source, target and release level to java 9 (which required a maven-compiler-plugin upgrade).

2. Picked `org.danekja.jdk.serializable.functional` for a module name base on groupid/artifactid. [Stephen Colebourne suggests](https://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html) using the largest common packagename but that would be org.danekja.java and that seemed to generic. 
You could probably drop the 'jdk' from the module name but I kept it in for recognizability.

3. Added an `Automatic-Module-Name` manifest entry using the above-picked name. This ensures a base level of compliancy with jigsaw (it ensures other libraries can write a module-info while depending on this library).

4. Added a module-info.java which was really easy since this library doesn't have any dependencies and exports everything in its two packages. This is full jigsaw compliancy.


Step 4 makes step 3 superfluous (the manifest entry can be dropped). You could also delete the module-info and only go with step 1 through 3 (if you really want to you can even drop step 1 and use only step 2 and 3 as the source/target level is only required for the module-info.java).

You could also use `open module org.danekja.jdk.serializable.functional` instead of just `module org.danekja.jdk.serializable.functional` in the module-info if you wanted to open all classes up for reflection access, though I don't think it's necessary. This would basically be the same as what happens now on java 8 classpath.